### PR TITLE
fix: check visisted status with level

### DIFF
--- a/Traverser.js
+++ b/Traverser.js
@@ -1,12 +1,34 @@
-function forEach ({ backward, callback, dataset, filter, forward, term, visited }) {
+import toNT from '@rdfjs/to-ntriples'
+
+class Visisted {
+  constructor () {
+    this.quadLevel = new Map()
+  }
+
+  add (quad, level) {
+    this.quadLevel.set(toNT(quad), level)
+  }
+
+  has (quad, level) {
+    const seenAt = this.quadLevel.get(toNT(quad))
+
+    if (seenAt === undefined) {
+      return false
+    }
+
+    return seenAt <= level
+  }
+}
+
+function forEach ({ backward, callback, dataset, filter, forward, term, visited = new Visisted() }) {
   const next = (term, level) => {
     const checkMatches = matches => {
       for (const quad of matches) {
-        if (visited.has(quad)) {
+        if (visited.has(quad, level)) {
           continue
         }
 
-        visited.add(quad)
+        visited.add(quad, level)
 
         const args = { dataset, level, quad }
 
@@ -51,8 +73,7 @@ class Traverser {
       dataset,
       filter: this.filter,
       forward: this.forward,
-      term,
-      visited: this.factory.dataset()
+      term
     })
   }
 
@@ -65,8 +86,7 @@ class Traverser {
       dataset,
       filter: this.filter,
       forward: this.forward,
-      term,
-      visited: this.factory.dataset()
+      term
     })
 
     return result
@@ -83,8 +103,7 @@ class Traverser {
       dataset,
       filter: this.filter,
       forward: this.forward,
-      term,
-      visited: this.factory.dataset()
+      term
     })
 
     return result

--- a/test/Traverser.test.js
+++ b/test/Traverser.test.js
@@ -3,7 +3,14 @@ import toNT from '@rdfjs/to-ntriples'
 import { describe, it } from 'mocha'
 import toCanonical from 'rdf-dataset-ext/toCanonical.js'
 import Traverser from '../Traverser.js'
-import TraverserExample, { backwardStop, callbackCall, filterCall, forwardStop, visitOnce } from './support/Example.js'
+import TraverserExample, {
+  backwardStop,
+  callbackCall,
+  filterCall,
+  forwardStop,
+  visitOnce,
+  visitOnceLevel
+} from './support/Example.js'
 import rdf from './support/factory.js'
 
 const ns = rdf.namespace('http://example.org/')
@@ -49,6 +56,15 @@ describe('Traverser', function () {
 
     it('should visit quads only once', () => {
       const example = visitOnce()
+      const traverser = new Traverser(...example.args)
+
+      traverser.forEach(example, () => {})
+
+      example.checkFilterCalls()
+    })
+
+    it('should visit quads only once unless the level is lower or equal', () => {
+      const example = visitOnceLevel()
       const traverser = new Traverser(...example.args)
 
       traverser.forEach(example, () => {})
@@ -102,6 +118,15 @@ describe('Traverser', function () {
 
     it('should visit quads only once', () => {
       const example = visitOnce()
+      const traverser = new Traverser(...example.args)
+
+      traverser.match(example)
+
+      example.checkFilterCalls()
+    })
+
+    it('should visit quads only once unless the level is lower or equal', () => {
+      const example = visitOnceLevel()
       const traverser = new Traverser(...example.args)
 
       traverser.match(example)
@@ -188,6 +213,15 @@ describe('Traverser', function () {
 
     it('should visit quads only once', () => {
       const example = visitOnce()
+      const traverser = new Traverser(...example.args)
+
+      traverser.reduce(example, () => {})
+
+      example.checkFilterCalls()
+    })
+
+    it('should visit quads only once unless the level is lower or equal', () => {
+      const example = visitOnceLevel()
       const traverser = new Traverser(...example.args)
 
       traverser.reduce(example, () => {})

--- a/test/support/Example.js
+++ b/test/support/Example.js
@@ -1,4 +1,5 @@
 import { deepStrictEqual, strictEqual } from 'assert'
+import toNT from '@rdfjs/to-ntriples'
 import toCanonical from 'rdf-dataset-ext/toCanonical.js'
 import rdf from './factory.js'
 
@@ -95,7 +96,7 @@ class Example {
     this.filterCalls.forEach((filterCall, index) => {
       const actualFilterCall = this.actualFilterCalls[index]
 
-      strictEqual(actualFilterCall[0].quad.toString(), filterCall.quad.toString())
+      strictEqual(toNT(actualFilterCall[0].quad), toNT(filterCall.quad))
       strictEqual(actualFilterCall[0].dataset, this.dataset)
       strictEqual(actualFilterCall[0].level, filterCall.level)
     })
@@ -107,7 +108,7 @@ class Example {
     this.forEachCalls.forEach((forEachCall, index) => {
       const actualForEachCall = this.actualForEachCalls[index]
 
-      strictEqual(actualForEachCall[0].quad.toString(), forEachCall.quad.toString())
+      strictEqual(toNT(actualForEachCall[0].quad), toNT(forEachCall.quad))
       strictEqual(actualForEachCall[0].dataset, this.dataset)
       strictEqual(actualForEachCall[0].level, forEachCall.level)
     })
@@ -119,7 +120,7 @@ class Example {
     this.reduceCalls.forEach((reduceCall, index) => {
       const actualReduceCall = this.actualReduceCalls[index]
 
-      strictEqual(actualReduceCall[0].quad.toString(), reduceCall[0].quad.toString(), true)
+      strictEqual(toNT(actualReduceCall[0].quad), toNT(reduceCall[0].quad))
       strictEqual(actualReduceCall[0].dataset, this.dataset)
       strictEqual(actualReduceCall[0].level, reduceCall[0].level)
       deepStrictEqual(actualReduceCall[1], reduceCall[1])
@@ -231,11 +232,32 @@ function visitOnce () {
   })
 }
 
+function visitOnceLevel () {
+  return new Example({
+    term: ns.a,
+    dataset: [
+      [ns.a, ns.p1, ns.a],
+      [ns.a, ns.p2, ns.b]
+    ],
+    filterCalls: [{
+      level: 0,
+      quad: [ns.a, ns.p1, ns.a]
+    }, {
+      level: 1,
+      quad: [ns.a, ns.p2, ns.b]
+    }, {
+      level: 0,
+      quad: [ns.a, ns.p2, ns.b]
+    }]
+  })
+}
+
 export default Example
 export {
   backwardStop,
   callbackCall,
   filterCall,
   forwardStop,
-  visitOnce
+  visitOnce,
+  visitOnceLevel
 }


### PR DESCRIPTION
The visited state was only checked based on the quad, not the level. This behavior could cause a quad to be discarded on a higher level, and it will not be visited again on a lower level. This PR stores the level with the visited state and compares the level if the quad has already been visited.

fixes #1 